### PR TITLE
Sửa "Những người thực hiện" thành heading 2

### DIFF
--- a/chapter_appendix_math/index_vn.md
+++ b/chapter_appendix_math/index_vn.md
@@ -111,7 +111,7 @@ statistics
 information-theory
 ```
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_appendix_math/single-variable-calculus_vn.md
+++ b/chapter_appendix_math/single-variable-calculus_vn.md
@@ -774,7 +774,7 @@ Taylor series are often helpful to answer such questions.
 
 <!-- ===================== Kết thúc dịch Phần 12 ==================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_appendix_math/statistics_vn.md
+++ b/chapter_appendix_math/statistics_vn.md
@@ -933,7 +933,7 @@ $$\tilde{\theta} = 2 \bar{X_n} = \frac{2}{n} \sum_{i=1}^n X_i.$$
 
 <!-- ===================== Kết thúc dịch Phần 13 ==================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_install/install_vn.md
+++ b/chapter_install/install_vn.md
@@ -314,7 +314,7 @@ Bạn có thể tìm thấy tất cả các phiên bản MXNet có sẵn thông 
 
 <!-- ========================================= REVISE PHẦN 2 - KẾT THÚC ===================================-->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_introduction/index_vn.md
+++ b/chapter_introduction/index_vn.md
@@ -2924,7 +2924,7 @@ Vật lý? Kỹ thuật? Kinh tế lượng?
 
 <!-- ========================================= REVISE PHẦN 1.7, 1.8 & 1.9 - KẾT THÚC =================================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_notation/index_vn.md
+++ b/chapter_notation/index_vn.md
@@ -150,7 +150,7 @@ The notation used throughout this book is summarized below.
 
 <!-- ===================== Kết thúc dịch Phần 1 ==================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_preface/index_vn.md
+++ b/chapter_preface/index_vn.md
@@ -676,7 +676,7 @@ Nếu không có thời gian, tài nguyên, mọi sự thảo luận cùng các 
 <!-- =================== Kết thúc dịch Phần 6 ================================-->
 <!-- ========================================= REVISE PHẦN 6 - KẾT THÚC ===================================-->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_preliminaries/index_vn.md
+++ b/chapter_preliminaries/index_vn.md
@@ -74,7 +74,7 @@ lookup-api
 
 <!-- ===================== Kết thúc dịch Phần 2 ==================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/chapter_preliminaries/linear-algebra_vn.md
+++ b/chapter_preliminaries/linear-algebra_vn.md
@@ -1016,7 +1016,7 @@ or other excellent resources :cite:`Strang.1993,Kolter.2008,Petersen.Pedersen.ea
 
 <!-- ===================== Kết thúc dịch Phần 12 ==================== -->
 
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy

--- a/contributor_template.md
+++ b/contributor_template.md
@@ -1,4 +1,4 @@
-### Những người thực hiện
+## Những người thực hiện
 Bản dịch trong trang này được thực hiện bởi:
 <!--
 Tác giả của mỗi Pull Request điền tên mình và tên những người review mà bạn thấy


### PR DESCRIPTION
Hiện tại "Những người thực hiện" là một mục con của "Thảo luận"
![image](https://user-images.githubusercontent.com/2201237/72783615-bb089580-3bdb-11ea-87d5-25d8edeae772.png)
