### PR TITLE
change label_name for HIGH priority chapter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,7 @@ chapter:introduction:
 chapter:math:
     - chapter_appendix_math/*
 
-chapter:preliminaries:
+chapter:preliminaries_HIGH_priority:
     - chapter_preliminaries/*
 
 chapter:computational-performance:


### PR DESCRIPTION
@duythanhvn thế này mình có thể đỡ công gán nhãn "priority:high". Khi nào muốn chương nào nhanh thì mình đổi lại label.