### PR TITLE
Không dịch Epoch.

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -95,6 +95,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | elementwise         | (theo) từng phần tử                                            |                       |
 | embedding           | embedding                                                      |                       |
 | end-to-end          | đầu-cuối                                                       | http://bit.ly/2OyYuEf |
+| epoch (in training) | epoch (khi huấn luyện)                                         |                       |
 | error analysis      | phân tích lỗi                                                  |                       |
 | error rate          | tỉ lệ lỗi                                                      |                       |
 | estimator           | bộ ước lượng                                                   |                       |


### PR DESCRIPTION
Mình nhớ là trước giờ không dịch từ epoch lúc huấn luyện.
Những cách dịch có sẵn trong TV như `thời kỳ, giai đoạn` đọc vô cũng không hiểu được nghĩa trong trường hợp này nên mình nghĩ không nên dịch.