### PR TITLE
One hot encoding, fully-connected và logit.

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -169,6 +169,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | linear discriminant analysis (LDA) | phân tích biệt thức tuyến tính |                       |
 | Long Short-term Memory (LSTM)      | bộ nhớ ngắn hạn dài            |                       |
 | logistic regression                | hồi quy logistic               |                       |
+| logit (in softmax)                 | logit                          |                       |
 | loss function                      | hàm mất mát                    |                       |
 
 ## M

--- a/glossary.md
+++ b/glossary.md
@@ -116,6 +116,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | fit                 | khớp           |               |
 | first principle     | định đề cơ bản |               |
 | functional anaylsis | giải tích hàm  |               |
+| fully-connected     | fully-connected  |               |
 
 ## G
 | English                        | Tiếng Việt                        | Thảo luận tại                                |

--- a/glossary.md
+++ b/glossary.md
@@ -169,7 +169,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | linear discriminant analysis (LDA) | phân tích biệt thức tuyến tính |                       |
 | Long Short-term Memory (LSTM)      | bộ nhớ ngắn hạn dài            |                       |
 | logistic regression                | hồi quy logistic               |                       |
-| logit (in softmax)                 | logit                          |                       |
+| logit (trong softmax)               | logit                          |                       |
 | loss function                      | hàm mất mát                    |                       |
 
 ## M

--- a/glossary.md
+++ b/glossary.md
@@ -206,6 +206,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | orthogonal         | trực giao          |                       |
 | orthonormal        | trực chuẩn         |                       |
 | overfit            | quá khớp           | http://bit.ly/2BvfPYA |
+| one-hot encoding   | mã hoá one-hot     |                       |
 | one-sided test     | kiểm định một phía |                       |
 | one-tailed test    | kiểm định một đuôi |                       |
 

--- a/glossary.md
+++ b/glossary.md
@@ -208,7 +208,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | orthogonal         | trực giao          |                       |
 | orthonormal        | trực chuẩn         |                       |
 | overfit            | quá khớp           | http://bit.ly/2BvfPYA |
-| one-hot encoding   | mã hoá one-hot     |                       |
+| one-hot encoding   | biễu diễn one-hot     |                       |
 | one-sided test     | kiểm định một phía |                       |
 | one-tailed test    | kiểm định một đuôi |                       |
 

--- a/glossary.md
+++ b/glossary.md
@@ -116,7 +116,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | fit                 | khớp           |               |
 | first principle     | định đề cơ bản |               |
 | functional anaylsis | giải tích hàm  |               |
-| fully-connected     | fully-connected  |               |
+| fully-connected     | kết nối đầy đủ        |               |
 
 ## G
 | English                        | Tiếng Việt                        | Thảo luận tại                                |


### PR DESCRIPTION
#732 có nhắc tới từ này. Mình đề xuất cũng giữ nguyên không dịch `One-hot`.
Update: Hiện mình đang giữ nguyên 3 từ này.
Context của `fully-connected`: https://github.com/aivivn/d2l-vn/pull/738/files#diff-176d4b05eecbf6877051af34210f4ed2R139