### PR TITLE
Add robustness, perturbation

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -287,7 +287,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | reinforcement learning         | học tăng cường                            |                                              |
 | representation learning        | học biểu diễn                             | [https://git.io/JvojG](https://git.io/JvojG) |
 | reward function                | hàm điểm thưởng                           |                                              |
-| robustness | khả năng kháng nhiễu | |
+| robustness | khả năng / tính kháng nhiễu | |
 | root mean squared error (RMSE) | căn bậc hai trung bình bình phương sai số | [https://git.io/Jvojr](https://git.io/Jvojr) |
 | running time                   | thời gian chạy                            |                                              |
 | region of rejection            | miền bác bỏ                               | [https://git.io/Jvoja](https://git.io/Jvoja) |

--- a/glossary.md
+++ b/glossary.md
@@ -253,6 +253,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | penalty | lượng phạt | |
 | perceptron                         | perceptron                 | [https://git.io/JvohC](https://git.io/JvohC)   |
 | performance                        | chất lượng                 | [http://bit.ly/36IzQcB](http://bit.ly/36IzQcB) |
+| perturbation | nhiễu | |
 | plateau (danh từ)                  | vùng nằm ngang             |                                                |
 | plateau (động từ)                  | nằm ngang                  |                                                |
 | pipeline                           | pipeline                   | [http://bit.ly/2OyYuEf](http://bit.ly/2OyYuEf) |
@@ -286,6 +287,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | reinforcement learning         | học tăng cường                            |                                              |
 | representation learning        | học biểu diễn                             | [https://git.io/JvojG](https://git.io/JvojG) |
 | reward function                | hàm điểm thưởng                           |                                              |
+| robustness | khả năng kháng nhiễu | |
 | root mean squared error (RMSE) | căn bậc hai trung bình bình phương sai số | [https://git.io/Jvojr](https://git.io/Jvojr) |
 | running time                   | thời gian chạy                            |                                              |
 | region of rejection            | miền bác bỏ                               | [https://git.io/Jvoja](https://git.io/Jvoja) |


### PR DESCRIPTION
quote thảo luận trên slack

**Tiep Vu**  8:25 AM
`Robustness through Perturbations`
@minhduc0711 đang dịch là
`Sự kiên định thông qua Nhiễu loạn`
Mình thấy có mấy vấn đề ở đây:
1. `Kiên định` chỉ dùng cho người hay cùng lắm là con vật chứ không dùng cho vật vô tri vô giác là mô hình ở đây. 
2. `through` không hẳn là thông qua mà hiểu sát hơn phải là kinh qua, trải qua
3. `Perturbation` có thể hiểu là `Nhiễu loạn`. Từ này khá gần nhưng mình chưa ưng lắm.

Cả cụm này có nghĩa chỉ tính bền vững kể cả khi trải qua những nhiễu loạn của môi trường (trong trường hợp này là đầu vào của mô hình).
Mời mọi người cho thêm ý kiến về cách dịch hai từ `Robustness` và `Pertubations` ở đây. Hai từ này xứng đáng được vào glossary. (edited) 
Cụm tính từ `robust to noise` mình thường dịch là `(có tính) kháng nhiễu`

**Nguyen Van Tam**  10:17 AM
Em xin đề xuất dịch là `Tính ổn định trước Nhiễu` hoặc `Tính ổn định trước Nhiễu đầu vào`

**Tân**  2:48 PM
Khả năng kháng nhiễu  hoặc `tính kháng nhiễu` (edited) 
Tiếng việt chỗ này nghe có vẻ xúc tích hơn tiếng anh :slightly_smiling_face: (edited) 

**minhduc0711**  4:32 PM
thế còn khi từ `robust` đi một mình thì sao nhỉ?
có thể dịch là `bền vững` không mọi người?

**ngcthuong**  6:34 PM
`Robust` ít đi một mình. Nên dịch là `kháng` thì ơn, dùng từ `ổn định` không thể hiện ý nghĩa gốc

**Tân**  6:37 PM
![image](https://user-images.githubusercontent.com/34294427/77326490-77054e80-6d4c-11ea-8245-83ce3f4c8b83.png)
`perturbations` nó được hàm ý khi nói về `robustness`

**ngcthuong**  12:42 AM
Từ chuyên ngành nó khác nghĩa chung, từ gần nghĩa nhiều nhưng đúng nghĩa sát nghĩa thì khó hơn. Dùng từ `ổn định` `bất ổn định` có thể gây nhầm lẫn với `certainty` và `uncertainty` 