### PR TITLE
Add bandit.

### DIFF
--- a/chapter_introduction/index_vn.md
+++ b/chapter_introduction/index_vn.md
@@ -2194,7 +2194,7 @@ is the classic *multi-armed bandit problem*.
 
 Khi ở môi trường được quan sát đầy đủ, ta gọi bài toán học tăng cường này là *Quá trình Quyết định Markov* (*Markov Decision Process* -- MDP).
 Khi trạng thái không phụ thuộc vào các hành động trước đó, ta gọi bài toán này là *bài toán máy đánh bạc theo ngữ cảnh* (*contextual bandit problem*).
-Khi không có trạng thái, chỉ có một tập hợp các hành động có sẵn với điểm thưởng chưa biết ban đầu, bài toán kinh điển này là *bài toán máy đánh bạc đa nhánh* (*multi-armed bandit problem*).
+Khi không có trạng thái, chỉ có một tập hợp các hành động có sẵn với điểm thưởng chưa biết ban đầu, bài toán kinh điển này là *bài toán máy đánh bạc đa cần* (*multi-armed bandit problem*).
 
 <!-- =================== Kết thúc dịch Phần 26 ==================== -->
 

--- a/chapter_introduction/index_vn.md
+++ b/chapter_introduction/index_vn.md
@@ -2160,7 +2160,7 @@ Các thuật toán học tăng cường phải luôn lựa chọn giữa việc 
 #### MDPs, bandits, and friends
 -->
 
-#### MDPs, những kẻ trộm, và những người bạn
+#### MDPs, máy đánh bạc, và những người bạn
 
 <!--
 The general reinforcement learning problem
@@ -2193,8 +2193,8 @@ is the classic *multi-armed bandit problem*.
 -->
 
 Khi ở môi trường được quan sát đầy đủ, ta gọi bài toán học tăng cường này là *Quá trình Quyết định Markov* (*Markov Decision Process* -- MDP).
-Khi trạng thái không phụ thuộc vào các hành động trước đó, ta gọi bài toán này là *bài toán trộm ngữ cảnh* (*contextual bandit problem*).
-Khi không có trạng thái, chỉ có một tập hợp các hành động có sẵn với điểm thưởng chưa biết ban đầu, bài toán kinh điển này là *bài toán trộm đa nhánh* (*multi-armed bandit problem*).
+Khi trạng thái không phụ thuộc vào các hành động trước đó, ta gọi bài toán này là *bài toán máy đánh bạc theo ngữ cảnh* (*contextual bandit problem*).
+Khi không có trạng thái, chỉ có một tập hợp các hành động có sẵn với điểm thưởng chưa biết ban đầu, bài toán kinh điển này là *bài toán máy đánh bạc đa nhánh* (*multi-armed bandit problem*).
 
 <!-- =================== Kết thúc dịch Phần 26 ==================== -->
 

--- a/glossary.md
+++ b/glossary.md
@@ -33,6 +33,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | background noise        | nhiễu nền                      | [https://git.io/JvQxm](https://git.io/JvQxm) |
 | back-propagation        | lan truyền ngược               |                                              |
 | backward pass           | lượt truyền ngược              | [https://git.io/JvohG](https://git.io/JvohG) |
+| bandit                  | máy đánh bạc                   |  |
 | batch                   | batch                          | [https://git.io/JvojE](https://git.io/JvojE) |
 | batch size              | kích thước batch               | [https://git.io/JvXdK](https://git.io/JvXdK) |
 | benchmark               | đánh giá xếp hạng              | [https://git.io/JvQxY](https://git.io/JvQxY) |

--- a/glossary.md
+++ b/glossary.md
@@ -216,6 +216,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | model                        | mô hình                       |                                              |
 | model capacity               | năng lực mô hình              | [https://git.io/JvQA5](https://git.io/JvQA5) |
 | module                       | mô-đun                        |                                              |
+| multi-armed bandit           | máy đánh bạc đa cần           |  |
 | multi-class classification   | phân loại đa lớp              | [https://git.io/Jvoj0](https://git.io/Jvoj0) |
 | multinominal distribution    | phân phối đa thức             | [https://git.io/JvohQ](https://git.io/JvohQ) |
 | multitask learning           | học đa nhiệm                  | [https://git.io/JvohQ](https://git.io/JvohQ) |


### PR DESCRIPTION
Từ này nhớ trước đây có bàn với dịch rồi mà giờ tìm không ra, gần đây có xuất hiện trong #1053 .
Từ này nghĩa gốc là `đạo tặc` nhưng nghĩa hay dùng trong các bài toán RL là `máy đánh bạc`.

Nếu `bandit` đi một mình thì mình dịch là `Bài toán máy đánh bạc`, 
nếu đi trong cụm như `multi-arm bandit` thì dịch `máy đánh bạc đa cần`.