### PR TITLE
Add translation invariant, scale invariant

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -316,6 +316,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | sampling without replacement    | lấy mẫu không hoàn lại   | [https://git.io/JvQxu](https://git.io/JvQxu) |
 | satisficing metric              | phép đo thỏa mãn         | [https://git.io/JvQxY](https://git.io/JvQxY) |
 | scalar                          | số vô hướng              | [https://git.io/Jvoja](https://git.io/Jvoja) |
+| scale invariant | bất biến quy mô | |
 | scroing function                | hàm tính điểm            |                                              |
 | sentiment classification        | phân loại cảm xúc        |                                              |
 | sequence learning               | học chuỗi                | [https://git.io/JvQxa](https://git.io/JvQxa) |
@@ -354,6 +355,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | training set               | tập huấn luyện                 |                                              |
 | training dev set           | tập phát triển huấn luyện      |                                              |
 | training set performance   | chất lượng trên tập huấn luyện |                                              |
+| translation invariant | bất biến tịnh tiến | |
 | transcribe                 | phiên thoại                    | [https://git.io/JvojN](https://git.io/JvojN) |
 | transcription              | bản ghi thoại                  |                                              |
 | true negative              | âm tính thật                   |                                              |


### PR DESCRIPTION
**tranyenthy**: `translation invariant`  trong

> While previously, we might have required billions of parameters to represent just a single layer in an image-processing network, we now typically need just a few hundred.
> The price that we pay for this drastic modification is that our features will be translation invariant and that our layer can only take local information into account.
> All learning depends on imposing inductive bias.
> When that bias agrees with reality, we get sample-efficient models that generalize well to unseen data.

nên dịch là gì nhỉ mọi người?

**rootonchair**
`tính bất biến dịch chuyển` hoặc `tính bất biến di dời`.

**minhduc0711** 
hình như `translate` được dịch là `tịnh tiến` thì phải

**rootonchair**
Mình chưa thấy trong glossary từ này. Mà nếu là `tịnh tiến` thì có hơi bị giới hạn không?

**rootonchair**
Mình muốn hỏi thêm từ `scale` mình hay dịch là gì nhỉ? Sẵn cho `scale invariant` luôn

**minhduc0711**
trong ngữ cảnh hình học thì phép dời hình khái quát hơn phép tịnh tiến, ko biết **[link này](https://kien-thuc.fandom.com/vi/wiki/Ph%C3%A9p_d%E1%BB%9Di_h%C3%ACnh)** có legit ko :no_mouth:

**minhduc0711** 
scale thì mình hay dịch là `khoảng giá trị`, nhưng với ảnh chắc phải nghĩ từ khác

**minhduc0711**
hay dịch là `kích thước (ảnh)` nhỉ

**Nguyen Van Tam**
https://stats.stackexchange.com/questions/208936/what-is-translation-invariance-in-computer-vision-and-convolutional-neural-netwo. 
Mình đồng ý với **minhduc0711** dịch là `tịnh tiến`.

**Nguyen Van Tam** 
`scale` mình nhớ không nhầm có người còn dịch là` thang đo`

**rootonchair**
http://tratu.soha.vn/dict/vn_vn/T%E1%BB%8Bnh_ti%E1%BA%BFn

> dời chỗ sao cho mỗi đường thẳng nối hai điểm bất kì của vật luôn luôn song song với chính nó

Yup, đồng ý `tịnh tiến`

**minhduc0711**
`scale invariant` ám chỉ là nếu mình phóng to/thu nhỏ ảnh, thì feature vẫn giống nhau nhỉ

**rootonchair**
Đúng rồi

**Nguyen Van Tam**
Khó dịch phết :))

**minhduc0711**
thế mình nghĩ `kích thước` hợp lý rồi :v

**Phúc Lê**
'bất biến tịnh tiến' với 'bất biến quy mô'

**Nguyen Van Tam**
+1 `kích thước` :smiley:

**rootonchair** 
Từ này hơi bí, tạm thời mình sẽ delay lại. Tại vì theo nghĩa gốc thì `bất biến quy mô` sẽ tổng quát hơn.
https://physics.stackexchange.com/questions/90883/what-is-scale-invariance