### PR TITLE
Add feature map.

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -127,6 +127,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | false negative      | âm tính giả      |                                              |
 | false positive      | dương tính giả   |                                              |
 | feature             | đặc trưng        |                                              |
+| feature map (CNN)   | ánh xạ đặc trưng |                                              |
 | filter (CNN)        | bộ lọc           | [https://git.io/Jfe1I](https://git.io/Jfe1I) |
 | fit                 | khớp             | [https://git.io/JvKet](https://git.io/JvKet) |
 | first principle     | định đề cơ bản   | [https://git.io/JvKet](https://git.io/JvKet) |


### PR DESCRIPTION
Bên #1215 có xài từ `feature map` là `bản đồ đặc trưng`.
Mình hiểu từ map này giống trong mapping nên đề xuất là `ánh xạ đặc trưng`. Ánh xạ trong tiếng việt vừa là tính từ vừa là danh từ.