### PR TITLE
Thêm SVM

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -355,7 +355,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | subspace estimation             | ước lượng không gian con | [https://git.io/JvojD](https://git.io/JvojD) |
 | superscript                     | chỉ số trên              | [https://git.io/Jvoh1](https://git.io/Jvoj1) |
 | supervised learning             | học có giám sát          |                                              |
-| support vector machine (SVM)    | Máy vector trụ đỡ        |                                              |
+| support vector machine (SVM)    | Máy vector hỗ trợ        |                                              |
 | surprisal (information theory)  | lượng tin                | [https://git.io/Jvoh3](https://git.io/Jvoh3) |
 | surrogate objective             | mục tiêu thay thế        | [https://git.io/JvQxV](https://git.io/JvQxV) |
 | symbolic graph                  | đồ thị biểu tượng        | [https://git.io/JvojU](https://git.io/JvojU) |

--- a/glossary.md
+++ b/glossary.md
@@ -355,6 +355,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | subspace estimation             | ước lượng không gian con | [https://git.io/JvojD](https://git.io/JvojD) |
 | superscript                     | chỉ số trên              | [https://git.io/Jvoh1](https://git.io/Jvoj1) |
 | supervised learning             | học có giám sát          |                                              |
+| support vector machine (SVM)    | Máy vector trụ đỡ        |                                              |
 | surprisal (information theory)  | lượng tin                | [https://git.io/Jvoh3](https://git.io/Jvoh3) |
 | surrogate objective             | mục tiêu thay thế        | [https://git.io/JvQxV](https://git.io/JvQxV) |
 | symbolic graph                  | đồ thị biểu tượng        | [https://git.io/JvojU](https://git.io/JvojU) |


### PR DESCRIPTION
Bên #1309 có bạn đề xuất `Máy vector hỗ trợ`.
Mình thì hiểu `support vector` là cái vector vuông góc từ decision plane tới điểm gần nhất, giống như mấy cái trụ nhà giúp chống đỡ margin khỏi sụp xuống nên đề xuất là `Máy vector trụ đỡ` hoặc `Máy vector trụ cột`. 