### PR TITLE
Thêm Optimization landscape, loss landscape / surface.

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -278,7 +278,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | one-hot encoding     | biễu diễn one-hot  | [https://git.io/JvohR](https://git.io/JvohR) |
 | one-sided test       | kiểm định một phía | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | one-tailed test      | kiểm định một đuôi | [https://git.io/Jvoja](https://git.io/Jvoja) |
-| optimization landscape    | bối cảnh tối ưu  | [https://git.io/JvQxY](https://git.io/JvQxY) |
+| optimization landscape    | cảnh quan tối ưu  | [https://git.io/JvQxY](https://git.io/JvQxY) |
 | optimizing metric    | phép đo để tối ưu  | [https://git.io/JvQxY](https://git.io/JvQxY) |
 | orthogonal           | trực giao          | [https://git.io/JvKem](https://git.io/JvKem) |
 | orthonormal          | trực chuẩn         | [https://git.io/JvKem](https://git.io/JvKem) |

--- a/glossary.md
+++ b/glossary.md
@@ -230,6 +230,8 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | logit (trong softmax)              | logit                          | [https://git.io/JvohR](https://git.io/JvohR) |
 | log-likelihood function            | hàm log hợp lý                 | [https://git.io/Jvopx](https://git.io/Jvopx) |
 | loss function                      | hàm mất mát                    | [https://git.io/Jvojp](https://git.io/Jvojp) |
+| loss landscape                     | cảnh quan mất mát              |                                              |
+| loss surface                       | bề mặt mất mát                 |                                              |
 
 ## M
 | English                      | Tiếng Việt                    | Thảo luận tại                                |

--- a/glossary.md
+++ b/glossary.md
@@ -276,6 +276,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | one-hot encoding     | biễu diễn one-hot  | [https://git.io/JvohR](https://git.io/JvohR) |
 | one-sided test       | kiểm định một phía | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | one-tailed test      | kiểm định một đuôi | [https://git.io/Jvoja](https://git.io/Jvoja) |
+| optimization landscape    | bối cảnh tối ưu  | [https://git.io/JvQxY](https://git.io/JvQxY) |
 | optimizing metric    | phép đo để tối ưu  | [https://git.io/JvQxY](https://git.io/JvQxY) |
 | orthogonal           | trực giao          | [https://git.io/JvKem](https://git.io/JvKem) |
 | orthonormal          | trực chuẩn         | [https://git.io/JvKem](https://git.io/JvKem) |


### PR DESCRIPTION
https://github.com/aivivn/d2l-vn/pull/1440/files#diff-f536120c51c52103dbac05ea7871630bR472

Từ này `Optimization landscape` mình hiểu là đồng nghĩa với `loss landscape` cũng như `loss surface` là chỉ cảnh quan / hình dạng trên không gian đa chiều của hàm mất mát theo tham số, nên đề xuất là: `cảnh quan tối ưu`.
Mọi người cho ý kiến. 
https://losslandscape.com/faq/

Trong sách mình chưa thấy 2 từ kia nhưng nếu cần mình thảo luận cách dịch cho `loss landscape / surface` luôn. 