### PR TITLE
Add dimensionality

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -103,6 +103,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | dev set performance       | chất lượng trên tập phát triển  |                                              |
 | development set           | tập phát triển                  |                                              |
 | differentiable            | khả vi                          | [https://git.io/JvKee](https://git.io/JvKee) |
+| dimension                   |  chiều                         |                                       |
 | dimensionality            | kích thước chiều                |                                              |
 | distribution              | phân phối                       |                                              |
 | domain adaptation         | thích ứng miền                  |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -103,6 +103,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | dev set performance       | chất lượng trên tập phát triển  |                                              |
 | development set           | tập phát triển                  |                                              |
 | differentiable            | khả vi                          | [https://git.io/JvKee](https://git.io/JvKee) |
+| dimensionality            | kích thước chiều                |                                              |
 | distribution              | phân phối                       |                                              |
 | domain adaptation         | thích ứng miền                  |                                              |
 | dot product               | tích vô hướng (hoặc tích trong) | [https://git.io/JvKem](https://git.io/JvKem) |


### PR DESCRIPTION
Mình thấy từ này hay được dịch là `số chiều`, nhưng dùng từ này trong ngữ cảnh sau thì mình thấy không chuẩn lắm 

_"the subsequent average pooling layer is used to reduce the dimensionality"_

Mình tạm thời đề xuất như thế này, nhưng chắc tùy vào context để dịch thì tốt hơn (e.g. chiều không gian, chiều kênh,...)