### PR TITLE
Add gradient clippling

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -166,6 +166,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | global maximum                 | giá trị lớn nhất                  | [https://git.io/Jvopx](https://git.io/Jvopx)                                               |
 | global minimum                 | giá trị nhỏ nhất                  | [https://git.io/Jvopx](https://git.io/Jvopx)                                               |
 | global interpreter lock        | khóa trình thông dịch toàn cục    | [https://git.io/JfGiV](https://git.io/JfGiV)                                               |
+| gradient clipping              | gọt gradient                      |                                                                                            |
 | gradient descent               | hạ gradient                       | [https://git.io/JvQxY](https://git.io/JvQxY), [https://git.io/JvQxW](https://git.io/JvQxW) |
 | graphical model                | mô hình đồ thị                    |                                                                                            |
 | ground truth                   | nhãn gốc                          | [https://git.io/JvQxl](https://git.io/JvQxl)                                               |


### PR DESCRIPTION
Quote thảo luận trên Slack

> **nguyenduydu**
Mình đang dịch phần rnn-scratch_vn thấy có cụm gradient clipping , mình địch là cắt gradient liệu có ổn không mọi người?
Ngữ cảnh:
Gradient clipping prevents gradient explosion (but it cannot fix vanishing gradients).
**Tiep Vu** 
Mình thấy cắt gradient ok.
**ngcthuong** 
Clipping là “gọt” thì chuẩn hơn
Bởi vì thường nó kéo giá trị không quá khoảng nào đấy
**Tiep Vu**  
Theo mình thì cắt và gọt không khác nhau lắm. Anyway, clipping grass trong ngôn ngữ thông thường được dịch là  cắt cỏ chứ không phải gọt cỏ.
**ngcthuong**  
Mình thì lại nghĩ khác
Bên mình hay dùng từ này lắm, thường nó là ép khoảng trên dưới ko quá. Cắt thì thường chỉ 1 đầu thôi
Vì mình thấy nó luôn luôn được dùng là “clipping” chứ không dùng từ “cut”.
Tương tự thuật toán graph cut cũng không thay bằng graph clip
Cut thường ám chỉ một lát phẳng thì phải
**Tiep Vu** 
ok, vậy mình cũng vote cho gọt