### PR TITLE
Amend "memory cell"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -258,7 +258,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | max pooling                  | gộp cực đại                   | [https://git.io/JfGi6](https://git.io/JfGi6) |
 | maximum likelihood estimator | bộ ước lượng hợp lý cực đại   |                                              |
 | mean squared error (MSE)     | trung bình bình phương sai số | [https://git.io/Jvojr](https://git.io/Jvojr) |
-| memory cell                  | ô nhớ                 |                                              |
+| memory cell                  | ô ký ức                       |                                              |
 | metric                       | phép đo                       |                                              |
 | minibatch                    | minibatch                     | [https://git.io/JvojE](https://git.io/JvojE) |
 | misclassified                | bị phân loại nhầm             |                                              |


### PR DESCRIPTION
Trong #1672 có thống nhất dịch `memory cell` là `ô nhớ`. Tuy nhiên khi review LSTM #1659 #1669 thì mình nghĩ `memory` ở đây là `ký ức` sẽ hợp lý hơn.