### PR TITLE
Add "beam search"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -50,7 +50,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | Blackbox dev set        | tập phát triển Blackbox        | [https://git.io/JvQx3](https://git.io/JvQx3) |
 | bounding box            | khung chứa                     | [https://git.io/JvQxs](https://git.io/JvQxs) |
 | broadcast               | lan truyền                     | [https://git.io/Jvoj3](https://git.io/Jvoj3) |
-| beam search             | tìm kiếm beam                  | [https://git.io/Jf9Nl](https://git.io/Jf9Nl) |
+| beam search             | tìm kiếm chùm                  | [https://git.io/Jf9Nl](https://git.io/Jf9Nl) |
 
 ## C
 | English                             | Tiếng Việt             | Thảo luận tại                                |

--- a/glossary.md
+++ b/glossary.md
@@ -50,6 +50,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | Blackbox dev set        | tập phát triển Blackbox        | [https://git.io/JvQx3](https://git.io/JvQx3) |
 | bounding box            | khung chứa                     | [https://git.io/JvQxs](https://git.io/JvQxs) |
 | broadcast               | lan truyền                     | [https://git.io/Jvoj3](https://git.io/Jvoj3) |
+| beam search             | tìm kiếm beam                  |                                              |
 
 ## C
 | English                             | Tiếng Việt             | Thảo luận tại                                |

--- a/glossary.md
+++ b/glossary.md
@@ -50,7 +50,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | Blackbox dev set        | tập phát triển Blackbox        | [https://git.io/JvQx3](https://git.io/JvQx3) |
 | bounding box            | khung chứa                     | [https://git.io/JvQxs](https://git.io/JvQxs) |
 | broadcast               | lan truyền                     | [https://git.io/Jvoj3](https://git.io/Jvoj3) |
-| beam search             | tìm kiếm beam                  |                                              |
+| beam search             | tìm kiếm beam                  | [https://git.io/Jf9Nl](https://git.io/Jf9Nl) |
 
 ## C
 | English                             | Tiếng Việt             | Thảo luận tại                                |


### PR DESCRIPTION
Hồi xưa học trong giáo trình thì thuật ngữ này được dịch là "tìm kiếm beam", và cũng thấy khá nhiều bài giảng, bài viết và giáo trình sử dụng dựa trên kết quả tìm kiếm Google. Thấy có hai phần các bạn dịch là `tìm kiếm chùm tia` thấy hơi sao sao? Mọi ng thảo luận xem nên giữ nguyên hay dịch chữ beam.