### PR TITLE
Add "positional encoding"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -340,6 +340,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | population                         | tổng thể                   | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | p-value                            | trị số p                   | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | position-wise feed-forward network           | mạng truyền xuôi theo vị trí                |  |
+| positional encoding                | biểu diễn vị trí           |  |
 
 ## Q
 | English               | Tiếng Việt            | Thảo luận tại                                |


### PR DESCRIPTION
Có thể từ này sẽ có bạn ở các phần khác (của attention và transformer) là "mã hoá vị trí". Cách này cũng ổn, nhưng mình thấy dịch là "biểu diễn vị trí" sẽ thống nhất với cách dịch "one-hot encoding". Mn góp ý xem sao :D 