### PR TITLE
Amend "recurrent"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -165,7 +165,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 ## G
 | English                        | Tiếng Việt                        | Thảo luận tại                                                                              |
 |--------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------|
-| gated recurrent unit           | nút truy hồi có cổng      | |
+| gated recurrent unit           | nút hồi tiếp có cổng      | |
 | Gaussian distribution          | phân phối Gauss (phân phối chuẩn) | [https://git.io/JvohV](https://git.io/JvohV)                                               |
 | Gaussian noise                 | nhiễu Gauss                       |                                                                                            |
 | generalization error           | lỗi khái quát                     | [https://git.io/Jvohm](https://git.io/Jvohm)                                               |
@@ -360,7 +360,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | recall                            | recall                                    |                                              |
 | receptive field (CNN)             | vùng tiếp nhận                            | [https://git.io/Jftwh](https://git.io/Jftwh) |
 | recognition                       | nhận dạng                                 |                                              |
-| recurrent neural network          | mạng nơ-ron truy hồi                      |                                              |
+| recurrent neural network          | mạng nơ-ron hồi tiếp                     |                                              |
 | rectified linear unit (ReLU)      | đơn vị tuyến tính chỉnh lưu               | [https://git.io/JvohI](https://git.io/JvohI) |
 | regressor                         | bộ hồi quy                                | [https://git.io/JvKee](https://git.io/JvKee) |
 | regularization                    | điều chuẩn                                |                                              |


### PR DESCRIPTION
Thảo luận trên slack của anh Tiệp. Mình cũng đồng tình với cách dịch này. Mong mọi người cho ý kiến

> Anh thấy từ “hồi tiếp” mà anh Ngọc đề xuất hợp lý.
re = hồi, current = tiếp
Trong vật lý :
Hồi tiếp là một phương pháp lấy tín hiệu ngõ ra của một hệ thống nào đó, và đưa ngược trở lại đầu vào của chính nó, để góp phần thay đổi, không chế hoặc điều khiển đầu vào.
http://shortn/_f0q1wyMYyU
cái RNN cũng nghĩa như vậy, có nhiều unit đặt liên tiếp nhau nhưng thực ra bên trong cấu trúc giống nhau.
Cũng là lấy đầu ra rồi đưa lại vào chính nó.