### PR TITLE
Add "warmup"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -484,7 +484,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 ## W
 | English                                   | Tiếng Việt        | Thảo luận tại                                |
 |-------------------------------------------|-------------------|----------------------------------------------|
-| warmup (trong định thời tốc độ học)       | khởi động         | [https://git.io/JJIT5](https://git.io/JJIT5) |
+| warmup (in learning rate scheduling)       | khởi động     | [https://git.io/JJIT5](https://git.io/JJIT5) |
 | weight decay                              | suy giảm trọng số | [https://git.io/JvQxK](https://git.io/JvQxK) |
 | well-behaved function (analytic function) | hàm khả vi vô hạn | [https://git.io/JvojL](https://git.io/JvojL) |
 | whitening data                            | tẩy trắng dữ liệu |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -484,9 +484,8 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 ## W
 | English                                   | Tiếng Việt        | Thảo luận tại                                |
 |-------------------------------------------|-------------------|----------------------------------------------|
+| warmup (trong định thời tốc độ học)       | khởi động         | [https://git.io/JJIT5](https://git.io/JJIT5) |
 | weight decay                              | suy giảm trọng số | [https://git.io/JvQxK](https://git.io/JvQxK) |
 | well-behaved function (analytic function) | hàm khả vi vô hạn | [https://git.io/JvojL](https://git.io/JvojL) |
 | whitening data                            | tẩy trắng dữ liệu |                                              |
 | wrapper function (trong lập trình)        | hàm wrapper       | [https://git.io/Jvohm](https://git.io/Jvohm) |
-| warmup (trong định thời tốc độ học)       | khởi động | |
-

--- a/glossary.md
+++ b/glossary.md
@@ -488,3 +488,5 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | well-behaved function (analytic function) | hàm khả vi vô hạn | [https://git.io/JvojL](https://git.io/JvojL) |
 | whitening data                            | tẩy trắng dữ liệu |                                              |
 | wrapper function (trong lập trình)        | hàm wrapper       | [https://git.io/Jvohm](https://git.io/Jvohm) |
+| warmup (trong định thời tốc độ học)       | khởi động | |
+


### PR DESCRIPTION
Từ warmup này xuất hiện trong phần Learning rate scheduler.
Mình tạm đề xuất là `khởi động`, mượn bên thể thao. Mà vẫn phân vân vì ngày xưa đi trường hè, có thầy Hưng (director VinAI giờ) có trình bày về khởi đầu nguội, rồi có 1 cụm từ `làm nóng` gì đó. Nhớ mang máng vậy.