### PR TITLE
Add "frontend" and "backend"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -34,6 +34,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 ## B
 | English                                | Tiếng Việt                     | Thảo luận tại                                |
 |----------------------------------------|--------------------------------|----------------------------------------------|
+| backend                                | bộ xử lý nền                   |                                              |
 | background noise                       | nhiễu nền                      | [https://git.io/JvQxm](https://git.io/JvQxm) |
 | backpropagation                        | lan truyền ngược               |                                              |
 | backpropagation through time           | lan truyền ngược qua thời gian |                                              |
@@ -161,6 +162,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | flatten                    | trải phẳng           | [https://git.io/JvohO](https://git.io/JvohO) |
 | forward pass               | lượt truyền xuôi     | [https://git.io/JvohG](https://git.io/JvohG) |
 | framework                  | framework            |                                              |
+| frontend                   | bộ xử lý trước       |                                              |
 | functional analysis        | giải tích hàm        |                                              |
 | fully-connected            | kết nối đầy đủ       | [https://git.io/JvohR](https://git.io/JvohR) |
 

--- a/glossary.md
+++ b/glossary.md
@@ -34,7 +34,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 ## B
 | English                                | Tiếng Việt                     | Thảo luận tại                                |
 |----------------------------------------|--------------------------------|----------------------------------------------|
-| backend                                | bộ xử lý nền                   |                                              |
+| backend                                | back-end                   |                                              |
 | background noise                       | nhiễu nền                      | [https://git.io/JvQxm](https://git.io/JvQxm) |
 | backpropagation                        | lan truyền ngược               |                                              |
 | backpropagation through time           | lan truyền ngược qua thời gian |                                              |
@@ -162,7 +162,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | flatten                    | trải phẳng           | [https://git.io/JvohO](https://git.io/JvohO) |
 | forward pass               | lượt truyền xuôi     | [https://git.io/JvohG](https://git.io/JvohG) |
 | framework                  | framework            |                                              |
-| frontend                   | bộ xử lý trước       |                                              |
+| frontend                   | front-end      |                                              |
 | functional analysis        | giải tích hàm        |                                              |
 | fully-connected            | kết nối đầy đủ       | [https://git.io/JvohR](https://git.io/JvohR) |
 


### PR DESCRIPTION
2 từ này xuất hiện khá nhiều trong #2025. Theo ý hiểu của em thì dịch ra được thành `bộ xử lý nền` và `bộ xử lý trước`. Tuy nhiên nếu giữ nguyên tiếng Anh em thấy cũng khá ổn.