### PR TITLE
Add "bus" and "cache"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -54,7 +54,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | blackbox dev set                       | tập phát triển blackbox        | [https://git.io/JvQx3](https://git.io/JvQx3) |
 | bounding box                           | khung chứa                     | [https://git.io/JvQxs](https://git.io/JvQxs) |
 | broadcast                              | lan truyền                     | [https://git.io/Jvoj3](https://git.io/Jvoj3) |
-| bus                                    | kênh truyền                    |                                              |
+| bus                                    | bus                    |                                              |
 
 ## C
 

--- a/glossary.md
+++ b/glossary.md
@@ -54,11 +54,13 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | blackbox dev set                       | tập phát triển blackbox        | [https://git.io/JvQx3](https://git.io/JvQx3) |
 | bounding box                           | khung chứa                     | [https://git.io/JvQxs](https://git.io/JvQxs) |
 | broadcast                              | lan truyền                     | [https://git.io/Jvoj3](https://git.io/Jvoj3) |
+| bus                                    | kênh truyền                    |                                              |
 
 ## C
 
 | English                         | Tiếng Việt              | Thảo luận tại                                |
 |---------------------------------|-------------------------|----------------------------------------------|
+| cache                           | bộ nhớ đệm              |
 | (strictly) convex function      | hàm lồi (chặt)          | [https://git.io/JvohV](https://git.io/JvohV) |
 | candidate hidden state          | trạng thái ẩn tiềm năng |                                              |
 | candidate memory                | ô nhớ tiềm năng         |                                              |


### PR DESCRIPTION
2 thuật ngữ này xuất hiện nhiều trong phần Hardware và một số phần khác. Em đã xem bản dịch của mọi người ở chương này và cách dịch cũng khác nhau nên em nghĩ nên thống nhất cách dịch.
`bus` có thể giữ nguyên là `bus` hoặc dịch thành `kênh truyền`, `cổng kết nối bus` theo #2111, `phương tiện kết nối` theo #2140
`cache` có thể dịch thành `bộ nhớ cache` theo #2140, hoặc `bộ nhớ đệm`.