### PR TITLE
Add "switch" to glossary

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -449,6 +449,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | support vector machine (SVM)      | Máy vector hỗ trợ        |                                              |
 | surprisal (in information theory) | lượng tin                | [https://git.io/Jvoh3](https://git.io/Jvoh3) |
 | surrogate objective               | mục tiêu thay thế        | [https://git.io/JvQxV](https://git.io/JvQxV) |
+| switch                            | switch                   |                                              |
 | symbolic graph                    | đồ thị biểu tượng        | [https://git.io/JvojU](https://git.io/JvojU) |
 
 ## T

--- a/glossary.md
+++ b/glossary.md
@@ -449,7 +449,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | support vector machine (SVM)      | Máy vector hỗ trợ        |                                              |
 | surprisal (in information theory) | lượng tin                | [https://git.io/Jvoh3](https://git.io/Jvoh3) |
 | surrogate objective               | mục tiêu thay thế        | [https://git.io/JvQxV](https://git.io/JvQxV) |
-| switch                            | switch                   |                                              |
+| switch                            | bộ chuyển mạch                   |                                              |
 | symbolic graph                    | đồ thị biểu tượng        | [https://git.io/JvojU](https://git.io/JvojU) |
 
 ## T


### PR DESCRIPTION
Cách gọi đúng là "bộ chuyển mạch" nhưng bây giờ họ thường sử dụng từ switch luôn. Dù thống nhất như thế nào thì mình cũng cần rà lại vì từ này được dịch khác nhau ở nhiều chỗ