### PR TITLE
Add "normalize" and  "standardize"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -324,6 +324,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | nonparametric                     | phi tham số                       |                                                                                            |
 | norm                              | chuẩn                             | [https://git.io/JvKem](https://git.io/JvKem)                                               |
 | normal distribution               | phân phối chuẩn (phân phối Gauss) | [https://git.io/JvohV](https://git.io/JvohV)                                               |
+| normalize                         | chuẩn hóa                         |                                                                                            |
 | null hypothesis                   | giả thuyết gốc                    | [https://git.io/Jvoj1](https://git.io/Jvoj1)                                               |
 | numerical solution                | nghiệm xấp xỉ                     |                                                                                            |
 
@@ -436,6 +437,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | speech recognition                | nhận dạng giọng nói      |                                              |
 | squashing function                | hàm ép                   | [https://git.io/JvQA5](https://git.io/JvQA5) |
 | standard deviation                | độ lệch chuẩn            | [https://git.io/Jvohb](https://git.io/Jvohb) |
+| standardize                       | chuẩn hóa                |                                              |
 | state-of-the-art                  | tân tiến nhất            |                                              |
 | stationary point                  | điểm dừng                | [https://git.io/JvohC](https://git.io/JvohC) |
 | statistical inference             | suy luận thống kê        |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -437,7 +437,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | speech recognition                | nhận dạng giọng nói      |                                              |
 | squashing function                | hàm ép                   | [https://git.io/JvQA5](https://git.io/JvQA5) |
 | standard deviation                | độ lệch chuẩn            | [https://git.io/Jvohb](https://git.io/Jvohb) |
-| standardize                       | chuẩn hóa                |                                              |
+| standardize                       | chuẩn tắc hóa                |                                              |
 | state-of-the-art                  | tân tiến nhất            |                                              |
 | stationary point                  | điểm dừng                | [https://git.io/JvohC](https://git.io/JvohC) |
 | statistical inference             | suy luận thống kê        |                                              |


### PR DESCRIPTION
Trong feature scaling, `normalize` và `standardize` là hai thứ khác nhau. Một cái là scale về khoảng [0, 1], một cái là chuẩn hóa lại dữ liệu. Mình không rành trong thống kê họ có phân biệt rõ ràng 2 khái niệm này không. Trong một số tài liệu, họ vẫn dùng từ `normalize` mặc dù cách làm là `standardize` (ví dụ: `batch normalization`). Hiện tại mình chưa nghĩ là cách dịch cho từ `normalize`