### PR TITLE
Add "downsample" and "upsample"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -125,6 +125,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | distributed               | phân tán                        |                                              |
 | distribution              | phân phối                       |                                              |
 | domain adaptation         | thích ứng miền                  |                                              |
+| downsample        | giảm chiều                  |                                              |
 | dot product               | tích vô hướng (hoặc tích trong) | [https://git.io/JvKem](https://git.io/JvKem) |
 | dropout                   | dropout                         |                                              |
 
@@ -495,6 +496,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | underflow (numerical)     | tràn (số) dưới            | [https://git.io/JvohC](https://git.io/JvohC) |
 | unit (in neural networks) | nút                       | [https://git.io/Jvohm](https://git.io/Jvohm) |
 | unsupervised learning     | học không giám sát        |                                              |
+| upsample        | tăng chiều                  |                                              |
 
 ## V
 | English                    | Tiếng Việt         | Thảo luận tại                                |

--- a/glossary.md
+++ b/glossary.md
@@ -125,7 +125,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | distributed               | phân tán                        |                                              |
 | distribution              | phân phối                       |                                              |
 | domain adaptation         | thích ứng miền                  |                                              |
-| downsample        | giảm chiều                  |                                              |
+| downsample        | giảm mẫu                  |  [https://git.io/JvohC](https://git.io/JvohC)                          |
 | dot product               | tích vô hướng (hoặc tích trong) | [https://git.io/JvKem](https://git.io/JvKem) |
 | dropout                   | dropout                         |                                              |
 

--- a/glossary.md
+++ b/glossary.md
@@ -496,7 +496,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | underflow (numerical)     | tràn (số) dưới            | [https://git.io/JvohC](https://git.io/JvohC) |
 | unit (in neural networks) | nút                       | [https://git.io/Jvohm](https://git.io/Jvohm) |
 | unsupervised learning     | học không giám sát        |                                              |
-| upsample        | tăng chiều                  |                                              |
+| upsample        | tăng mẫu                  |   [https://git.io/JvohC](https://git.io/JvohC)                              |
 
 ## V
 | English                    | Tiếng Việt         | Thảo luận tại                                |


### PR DESCRIPTION
Trong xử lý tín hiệu:
```
downsample - Computer Definition. (1) To make a digital audio signal smaller by lowering its sampling rate or sample size (bits per sample)
```
Nhưng trong DL, từ này mang ý nghĩa giảm chiều của "mẫu" (feature maps). Mình nghĩ bỏ từ "mẫu" đi vì dễ hiểu nhầm là input sample.

Như thảo luận ở đây, `pooling` là một trường hợp đặc biệt của `downsample`. Ở #2289, `downsample` block có thể khối các conv có stride > 1. `upsample` block mình nghĩ sẽ gặp trong những phần liên quan tới segmentation.

https://www.quora.com/What-is-a-downsampling-layer-in-Convolutional-Neural-Network-CNN

