### PR TITLE
Add "pretrain"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -373,6 +373,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | posterior                          | hậu nghiệm                   | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | precision                          | precision                    |                                              |
 | preconditioning                    | tiền điều kiện               |                                              |
+| pre-train(ed)                        | tiền huấn luyện                    |                                              |
 | principal component analysis (PCA) | phân tích thành phần chính   | [https://git.io/JvojD](https://git.io/JvojD) |
 | prior                              | tiên nghiệm                  | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | probability theory                 | lý thuyết xác suất           |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -373,7 +373,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | posterior                          | hậu nghiệm                   | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | precision                          | precision                    |                                              |
 | preconditioning                    | tiền điều kiện               |                                              |
-| pre-train(ed)                        | tiền huấn luyện                    | [https://git.io/JJ1HO](https://git.io/JJ1HO) |
+| pre-train                        | tiền huấn luyện                    | [https://git.io/JJ1HO](https://git.io/JJ1HO) |
 | principal component analysis (PCA) | phân tích thành phần chính   | [https://git.io/JvojD](https://git.io/JvojD) |
 | prior                              | tiên nghiệm                  | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | probability theory                 | lý thuyết xác suất           |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -373,7 +373,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | posterior                          | hậu nghiệm                   | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | precision                          | precision                    |                                              |
 | preconditioning                    | tiền điều kiện               |                                              |
-| pre-train(ed)                        | tiền huấn luyện                    |                                              |
+| pre-train(ed)                        | tiền huấn luyện                    | [https://git.io/JJ1HO](https://git.io/JJ1HO) |
 | principal component analysis (PCA) | phân tích thành phần chính   | [https://git.io/JvojD](https://git.io/JvojD) |
 | prior                              | tiên nghiệm                  | [https://git.io/JvQA6](https://git.io/JvQA6) |
 | probability theory                 | lý thuyết xác suất           |                                              |


### PR DESCRIPTION
Khi nhắc tới từ `pretrain a model`, hay `a pretrained model` thì mình sẽ hiểu là model được huấn luyện trên tập dữ liệu khác (thường là lớn hơn). `Tiền huấn luyện` không biết đã rõ nghĩa chưa.

Liệu có nên thêm dấu `-` vào `pretrain` thành `pre-train` hay không.
