### PR TITLE
Amend category.

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -66,7 +66,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | candidate hidden state          | trạng thái ẩn tiềm năng  |                                              |
 | candidate memory                | ô nhớ tiềm năng          |                                              |
 | categorical variable            | biến hạng mục            | [https://git.io/JfeXx](https://git.io/JfeXx) |
-| category (in classification)    | lớp                      | [https://git.io/JvohG](https://git.io/JvohG) |
+| category                        | hạng mục                 | [https://git.io/JvohG](https://git.io/JvohG) |
 | causality                       | quan hệ nhân quả         |                                              |
 | chain rule                      | quy tắc dây chuyền       | [https://git.io/Jvojk](https://git.io/Jvojk) |
 | channel (in computer vision)    | kênh                     |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -66,7 +66,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | candidate hidden state          | trạng thái ẩn tiềm năng  |                                              |
 | candidate memory                | ô nhớ tiềm năng          |                                              |
 | categorical variable            | biến hạng mục            | [https://git.io/JfeXx](https://git.io/JfeXx) |
-| category                        | hạng mục                 | [https://git.io/JvohG](https://git.io/JvohG) |
+| category                        | hạng mục                 | [https://git.io/JJDKV](https://git.io/JJDKV) |
 | causality                       | quan hệ nhân quả         |                                              |
 | chain rule                      | quy tắc dây chuyền       | [https://git.io/Jvojk](https://git.io/Jvojk) |
 | channel (in computer vision)    | kênh                     |                                              |


### PR DESCRIPTION
Trong bài toán phân loại thì phân loại theo các `hạng mục` hay `lớp` đều là như nhau.
Từ này mình thấy không phải là từ khoá gì, vốn đáng ra không cần đưa vào glossary luôn. Vì có ở trong glossary nên thành ra có những PR fix (như #2329 ), với mình đang review vài chỗ thấy dịch `category` thành `lớp` đọc khá gượng gạo. Từ `lớp` bản thân nó mang rất nhiều nghĩa rồi, ở trường hợp này mình có từ khác thì nên dùng chứ không nên chuyển về `lớp` làm gì. 

Nếu mọi người đồng ý thì cứ merge để từ nay về sau không phải ép `category` thành lớp nữa thôi, còn các phần trước đã dịch cũng không sai nên mình nghĩ cũng không cần sửa lại.