### PR TITLE
Amend precision

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -378,7 +378,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | positional encoding                | biểu diễn vị trí             |                                              |
 | positive sample/example            | mẫu dương                    |                                              |
 | posterior                          | hậu nghiệm                   | [https://git.io/JvQA6](https://git.io/JvQA6) |
-| precision (vs accuracy metric)     | precision                    |               |
+| precision (vs accuracy metric)     | precision                    | [https://git.io/JJ9sl](https://git.io/JJ9sl)         |
 | preconditioning                    | tiền điều kiện               |                                              |
 | pre-train                        | tiền huấn luyện                    | [https://git.io/JJ1HO](https://git.io/JJ1HO) |
 | principal component analysis (PCA) | phân tích thành phần chính   | [https://git.io/JvojD](https://git.io/JvojD) |

--- a/glossary.md
+++ b/glossary.md
@@ -378,7 +378,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | positional encoding                | biểu diễn vị trí             |                                              |
 | positive sample/example            | mẫu dương                    |                                              |
 | posterior                          | hậu nghiệm                   | [https://git.io/JvQA6](https://git.io/JvQA6) |
-| precision                          | precision                    |                                              |
+| precision (vs accuracy metric)     | precision                    |               |
 | preconditioning                    | tiền điều kiện               |                                              |
 | pre-train                        | tiền huấn luyện                    | [https://git.io/JJ1HO](https://git.io/JJ1HO) |
 | principal component analysis (PCA) | phân tích thành phần chính   | [https://git.io/JvojD](https://git.io/JvojD) |


### PR DESCRIPTION
Precision trong glossary đang giữ nguyên không dịch, vì khi xét tới metric, `độ chính xác` đã dành cho `accuracy` rồi, và không có một cụm nào phổ biến cho precision metric này cả.
Nhưng trong các cách xài thông thường mình vẫn có thể linh động dịch thành `độ chính xác, tính đúng đắn, chuẩn xác`. https://github.com/aivivn/d2l-vn/pull/2344#discussion_r469371149

Mình bổ sung thêm context chỉ giữ nguyên `precision` khi nhắc tới metric precision / accuracy.