### PR TITLE
Amend "pixel"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -374,7 +374,8 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | perplexity (metric in NLP)         | perplexity                   | [https://git.io/Jf9KY](https://git.io/Jf9KY) |
 | perturbation                       | nhiễu                        | [https://git.io/JvQA1](https://git.io/JvQA1) |
 | pipeline                           | pipeline                     | [https://git.io/JvQxG](https://git.io/JvQxG) |
-| pixel                              | điểm ảnh / pixel (đơn vị đo) |                                              |
+| pixel (component of digital images)                              | điểm ảnh |                                              |
+| pixel (unit of measurement)                             | pixel (đơn vị đo) |                                              |
 | plateau (noun)                     | vùng nằm ngang               |                                              |
 | plateau (verb)                     | nằm ngang                    |                                              |
 | policy (in reinforcement learning) | chính sách                   | [https://git.io/Jvoj9](https://git.io/Jvoj9) |


### PR DESCRIPTION
Trên slack em và @rootonchair có bàn luận về từ này.

Từ này thường xuất hiện theo hai nghĩa. một là `đơn vị đo pixel`, hai là một `điểm ảnh`.
Trong chương 13 từ này xuất hiện nhiều dưới dạng đơn vị đo, nên em nghĩ nên linh hoạt giữ nguyên hoặc dịch ra `điểm ảnh`.
