### PR TITLE
Add "analogy"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -22,7 +22,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | algorithm's performance               | chất lượng thuật toán     |                                              |
 | alternative hypothesis                | giả thuyết đối            | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | analytical solution                   | nghiệm theo công thức     |                                              |
-| analogy                               | oại suy             |                                              |
+| analogy                               | loại suy             |                                              |
 | anchor box                            | khung neo                 |                                              |
 | approximate inference                 | suy luận gần đúng         |                                              |
 | approximate training                  | huấn luyện gần đúng       |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -22,6 +22,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | algorithm's performance               | chất lượng thuật toán     |                                              |
 | alternative hypothesis                | giả thuyết đối            | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | analytical solution                   | nghiệm theo công thức     |                                              |
+| analogy                               | phép loại suy             |                                              |
 | anchor box                            | khung neo                 |                                              |
 | approximate inference                 | suy luận gần đúng         |                                              |
 | approximate training                  | huấn luyện gần đúng       |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -22,7 +22,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | algorithm's performance               | chất lượng thuật toán     |                                              |
 | alternative hypothesis                | giả thuyết đối            | [https://git.io/Jvoja](https://git.io/Jvoja) |
 | analytical solution                   | nghiệm theo công thức     |                                              |
-| analogy                               | phép loại suy             |                                              |
+| analogy                               | oại suy             |                                              |
 | anchor box                            | khung neo                 |                                              |
 | approximate inference                 | suy luận gần đúng         |                                              |
 | approximate training                  | huấn luyện gần đúng       |                                              |


### PR DESCRIPTION
Từ này có thể dịch là `tương tự` như từ `similarity`, được dịch là `loại suy` có lẽ đúng hơn với `vec(𝑐)+vec(𝑏)−vec(𝑎)` để tìm từ còn lại.  Mình đọc qua bài báo https://arxiv.org/pdf/1901.09813.pdf, thì `analogy` được sử dụng khác từ `similarity` trong NLP.