### PR TITLE
Add "downstream task"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -132,6 +132,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | distribution              | phân phối                       |                                              |
 | domain adaptation         | thích ứng miền                  |                                              |
 | downsample                | giảm mẫu                        | [https://git.io/JvohC](https://git.io/JvohC) |
+| downstream task           | tác vụ hạ nguồn              | |
 | dot product               | tích vô hướng (hoặc tích trong) | [https://git.io/JvKem](https://git.io/JvKem) |
 | dropout                   | dropout                         |                                              |
 


### PR DESCRIPTION
Ở 1 vài phần trước, mình đã cố gắng lờ từ này đi bằng cách dịch là "tác vụ cụ thể". TS. Minh thì dịch là "theo từng task" (https://www.slideshare.net/minhpqn/deep-contexualized-representation, slide trang 22). 
 Nhưng ở chap NLP này từ "downstream task" này xuất hiện như là một thuật ngữ quen thuộc. Từ "downstream" thì có nghĩa "hạ lưu", "hạ nguồn", "xuôi dòng", v.v Từ "hạ lưu" thì nghe thuỷ lợi quá :) nên hiện tại mình chọn tạm "hạ nguồn" dù cũng có chút thuỷ lợi :))

