### PR TITLE
Add "task-specific/agnostic"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -484,6 +484,8 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 |----------------------------------------|-------------------------------------------|----------------------------------------------|
 | Taylor expansion                       | khai triển Taylor                         |                                              |
 | target data / distribution             | dữ liệu / phân phối mục tiêu              | [https://git.io/JvQAy](https://git.io/JvQAy) |
+| task-specific                          | chuyên biệt cho tác vụ                    |                                              |
+| task-agnostic                          | bất khả tri với cho tác vụ                |                                              |
 | tensor contraction                     | phép co tensor                            | [https://git.io/JvojX](https://git.io/JvojX) |
 | test set                               | tập kiểm tra                              |                                              |
 | test set performance                   | chất lượng trên tập kiểm tra              |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -485,7 +485,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 | Taylor expansion                       | khai triển Taylor                         |                                              |
 | target data / distribution             | dữ liệu / phân phối mục tiêu              | [https://git.io/JvQAy](https://git.io/JvQAy) |
 | task-specific                          | đặc thù cho tác vụ                    |                                              |
-| task-agnostic                          | bất khả tri với cho tác vụ                |                                              |
+| task-agnostic                          | không phân biệt tác vụ                |                                              |
 | tensor contraction                     | phép co tensor                            | [https://git.io/JvojX](https://git.io/JvojX) |
 | test set                               | tập kiểm tra                              |                                              |
 | test set performance                   | chất lượng trên tập kiểm tra              |                                              |

--- a/glossary.md
+++ b/glossary.md
@@ -484,7 +484,7 @@ Nếu bạn cho rằng một từ không nên dịch ra tiếng Việt, bạn c�
 |----------------------------------------|-------------------------------------------|----------------------------------------------|
 | Taylor expansion                       | khai triển Taylor                         |                                              |
 | target data / distribution             | dữ liệu / phân phối mục tiêu              | [https://git.io/JvQAy](https://git.io/JvQAy) |
-| task-specific                          | chuyên biệt cho tác vụ                    |                                              |
+| task-specific                          | đặc thù cho tác vụ                    |                                              |
 | task-agnostic                          | bất khả tri với cho tác vụ                |                                              |
 | tensor contraction                     | phép co tensor                            | [https://git.io/JvojX](https://git.io/JvojX) |
 | test set                               | tập kiểm tra                              |                                              |


### PR DESCRIPTION
"task-specific" - có thể dịch là  ~~"chuyên biệt cho tác vụ" hoặc "chuyên dụng cho tác vụ", v.v.~~ -> Dịch lại là `đặc thù cho tác vụ`. 

"task-agnostic" -  từ này có thể hiểu là "không phụ thuộc vào tác vụ", nhưng có từ hán vụ "bất khả tri" ~~nên mình tạm dịch là "bất khả tri với tác vụ".  Từ bất khả tri hoá ra mang ý tôn giáo~~ 
Đã dịch lại là `không phân biệt  cho tác vụ`. 